### PR TITLE
adjustments for tests, minor corrections

### DIFF
--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -43,12 +43,12 @@
 	bnd.identity;id='io.openems.edge.battery.bydcommercial',\
 	bnd.identity;id='io.openems.edge.battery.fenecon.commercial',\
 	bnd.identity;id='io.openems.edge.battery.fenecon.home',\
-	bnd.identity;id='io.openems.edge.battery.pylontech',\
-	bnd.identity;id='io.openems.edge.battery.soltaro',\
 	bnd.identity;id='io.openems.edge.batteryinverter.kaco.blueplanetgridsave',\
 	bnd.identity;id='io.openems.edge.batteryinverter.refu88k',\
 	bnd.identity;id='io.openems.edge.batteryinverter.sinexcel',\
 	bnd.identity;id='io.openems.edge.batteryinverter.sunspec',\
+	bnd.identity;id='io.openems.edge.battery.pylontech',\
+	bnd.identity;id='io.openems.edge.battery.soltaro',\
 	bnd.identity;id='io.openems.edge.bosch.bpts5hybrid',\
 	bnd.identity;id='io.openems.edge.bridge.http',\
 	bnd.identity;id='io.openems.edge.bridge.mbus',\
@@ -99,8 +99,8 @@
 	bnd.identity;id='io.openems.edge.controller.io.analog',\
 	bnd.identity;id='io.openems.edge.controller.io.channelsinglethreshold',\
 	bnd.identity;id='io.openems.edge.controller.io.fixdigitaloutput',\
-	bnd.identity;id='io.openems.edge.controller.io.heating.room',\
 	bnd.identity;id='io.openems.edge.controller.io.heatingelement',\
+	bnd.identity;id='io.openems.edge.controller.io.heating.room',\
 	bnd.identity;id='io.openems.edge.controller.io.heatpump.sgready',\
 	bnd.identity;id='io.openems.edge.controller.levl',\
 	bnd.identity;id='io.openems.edge.controller.pvinverter.fixpowerlimit',\

--- a/io.openems.edge.evcc/src/io/openems/edge/evcc/gridtariff/TimeOfUseGridTariffEvccImpl.java
+++ b/io.openems.edge.evcc/src/io/openems/edge/evcc/gridtariff/TimeOfUseGridTariffEvccImpl.java
@@ -27,10 +27,7 @@ import io.openems.edge.timeofusetariff.api.TimeOfUseTariff;
 )
 
 public class TimeOfUseGridTariffEvccImpl extends AbstractOpenemsComponent
-		implements
-			TimeOfUseTariff,
-			OpenemsComponent,
-			TimeOfUseGridTariffEvcc {
+		implements TimeOfUseTariff, OpenemsComponent, TimeOfUseGridTariffEvcc {
 
 	@Reference
 	private ComponentManager componentManager;
@@ -46,8 +43,7 @@ public class TimeOfUseGridTariffEvccImpl extends AbstractOpenemsComponent
 	private BridgeHttp httpBridge;
 
 	public TimeOfUseGridTariffEvccImpl() {
-		super(OpenemsComponent.ChannelId.values(),
-				TimeOfUseGridTariffEvcc.ChannelId.values());
+		super(OpenemsComponent.ChannelId.values(), TimeOfUseGridTariffEvcc.ChannelId.values());
 	}
 
 	@Activate
@@ -60,8 +56,8 @@ public class TimeOfUseGridTariffEvccImpl extends AbstractOpenemsComponent
 
 		this.httpBridge = this.httpBridgeFactory.get();
 
-		this.apiClient = new TimeOfUseGridTariffEvccApi(config.apiUrl(),
-				this.httpBridge);
+		this.apiClient = new TimeOfUseGridTariffEvccApi(config.apiUrl(), this.httpBridge,
+				this.componentManager.getClock());
 	}
 
 	@Deactivate
@@ -75,12 +71,12 @@ public class TimeOfUseGridTariffEvccImpl extends AbstractOpenemsComponent
 	 *
 	 * <p>
 	 * This method checks if the API client is available. If so, it fetches the
-	 * prices from the API client and returns a TimeOfUsePrices instance with
-	 * the current timestamp. If the API client is not available, it returns an
-	 * empty TimeOfUsePrices object.
+	 * prices from the API client and returns a TimeOfUsePrices instance with the
+	 * current timestamp. If the API client is not available, it returns an empty
+	 * TimeOfUsePrices object.
 	 *
-	 * @return the current time-of-use prices or an empty instance if the API
-	 *         client is unavailable.
+	 * @return the current time-of-use prices or an empty instance if the API client
+	 *         is unavailable.
 	 */
 	public TimeOfUsePrices getPrices() {
 		if (this.apiClient != null) {

--- a/io.openems.edge.evcc/test/io/openems/edge/evcc/solartariff/PredictorSolarTariffEvccImplTest.java
+++ b/io.openems.edge.evcc/test/io/openems/edge/evcc/solartariff/PredictorSolarTariffEvccImplTest.java
@@ -1,25 +1,29 @@
 package io.openems.edge.evcc.solartariff;
 
 import static io.openems.common.test.TestUtils.createDummyClock;
+import static io.openems.edge.bridge.http.dummy.DummyBridgeHttpFactory.cycleSubscriber;
+import static io.openems.edge.bridge.http.dummy.DummyBridgeHttpFactory.dummyBridgeHttpExecutor;
+import static io.openems.edge.bridge.http.dummy.DummyBridgeHttpFactory.dummyEndpointFetcher;
+import static io.openems.edge.bridge.http.dummy.DummyBridgeHttpFactory.ofBridgeImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
 import io.openems.edge.bridge.http.api.HttpError;
 import io.openems.edge.bridge.http.api.HttpResponse;
-import io.openems.edge.bridge.http.dummy.DummyBridgeHttpBundle;
+import io.openems.edge.bridge.http.api.UrlBuilder;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.ComponentTest;
 import io.openems.edge.common.test.DummyComponentManager;
 import io.openems.edge.predictor.api.prediction.LogVerbosity;
 import io.openems.edge.predictor.api.prediction.Prediction;
-import io.openems.edge.timeofusetariff.api.TimeOfUsePrices;
 
 public class PredictorSolarTariffEvccImplTest {
 
@@ -27,136 +31,269 @@ public class PredictorSolarTariffEvccImplTest {
 
 	@Test
 	public void testSolarTariffPrediction() throws Exception {
-		final var sut = new PredictorSolarTariffEvccImpl();
-		final var api = new PredictorSolarTariffEvccApi();
-		final var httpTestBundle = new DummyBridgeHttpBundle();
 		final var clock = createDummyClock();
-		
-		final LocalDateTime localCurrentHour = LocalDateTime.now().withSecond(0).withNano(0).withMinute(0);
-		final ZoneId localZone = ZoneId.systemDefault();
-		final ZonedDateTime localZoned = localCurrentHour.atZone(localZone);
-		final ZonedDateTime currentHour = localZoned.withZoneSameInstant(ZoneId.of("UTC"));
-		
-		final int expectedFirstValue = this.getSolarPredictionValue(localZoned);
-		final int expectedSecondHourValue = this.getSolarPredictionValue(localZoned.plusHours(1));
+		final var sut = new PredictorSolarTariffEvccImpl();
+		final var api = new PredictorSolarTariffEvccApi(clock);
 
-		new ComponentTest(sut).addReference("httpBridgeFactory", httpTestBundle.factory())
-				.addReference("componentManager", new DummyComponentManager(clock))
-				.activate(MyConfig.create().setId("predictor0").setUrl("http://evcc:7070/api/tariff/solar")
-						.setLogVerbosity(LogVerbosity.REQUESTED_PREDICTIONS).build())
+		final var url = "http://evcc:7070/api/tariff/solar";
+		final var endpointFetcher = dummyEndpointFetcher();
+		endpointFetcher.addEndpointHandler(endpoint -> {
+
+			if (endpoint.url().equals(UrlBuilder.parse(url).toEncodedString())) {
+				return HttpResponse.ok(this.generateDynamicJson(clock, 60));
+			}
+
+			throw HttpError.ResponseError.notFound();
+		});
+
+		final var executor = dummyBridgeHttpExecutor();
+
+		final var factory = ofBridgeImpl(//
+				() -> cycleSubscriber(), //
+				() -> endpointFetcher, //
+				() -> executor //
+		);
+		final var urlFail = "http://evcc:7070/api/tarif/solar";
+
+		final ZonedDateTime localCurrentHour = ZonedDateTime.now(clock).withSecond(0).withNano(0).withMinute(0);
+		ZonedDateTime currentHour = localCurrentHour.withZoneSameInstant(ZoneId.of("UTC"));
+
+		new ComponentTest(sut).addReference("httpBridgeFactory", factory)
+				.addReference("componentManager", new DummyComponentManager(clock)) //
+				.activate(//
+						MyConfig.create() //
+								.setId("predictor0") //
+								.setUrl(urlFail) //
+								.setLogVerbosity(LogVerbosity.REQUESTED_PREDICTIONS) //
+								.build())
 
 				// Case: API not found
-				.next(new TestCase("API Not Found").onBeforeProcessImage(() -> {
-					httpTestBundle.forceNextFailedResult(HttpError.ResponseError.notFound());
-					httpTestBundle.triggerNextCycle();
-				}).onAfterProcessImage(() -> {
-					assertEquals(Prediction.EMPTY_PREDICTION, sut.createNewPrediction(sut.getChannelAddresses()[0]));
-				}))
+				.next(new TestCase("API Not Found") //
+						.timeleap(clock, 10, ChronoUnit.SECONDS) //
+						.onAfterProcessImage(() -> {
+							executor.update();
+							assertEquals(Prediction.EMPTY_PREDICTION,
+									sut.createNewPrediction(sut.getChannelAddresses()[0]));
+						}))
+				.deactivate();
 
-				// Case: API unknown error
-				.next(new TestCase("API Unknown Error").onBeforeProcessImage(() -> {
-					httpTestBundle
-							.forceNextFailedResult(new HttpError.UnknownError(new Exception("Simulated failure")));
-					httpTestBundle.triggerNextCycle();
-				}).onAfterProcessImage(() -> {
-					assertEquals(Prediction.EMPTY_PREDICTION, sut.createNewPrediction(sut.getChannelAddresses()[0]));
-				}))
-				
+		new ComponentTest(sut).addReference("httpBridgeFactory", factory)
+				.addReference("componentManager", new DummyComponentManager(clock)) //
+				.activate(//
+						MyConfig.create() //
+								.setId("predictor0") //
+								.setUrl(url) //
+								.setLogVerbosity(LogVerbosity.REQUESTED_PREDICTIONS) //
+								.build())
+
 				// Case: API success
-				.next(new TestCase("API success").onBeforeProcessImage(() -> {
-					String jsonResponse = this.generateDynamicJson(60);
-					httpTestBundle.forceNextSuccessfulResult(HttpResponse.ok(jsonResponse));
-					httpTestBundle.triggerNextCycle();
-					//TODO how to check asynchronous httpBridge response?
-				}))
+				.next(new TestCase("API success") //
+						.timeleap(clock, 10, ChronoUnit.SECONDS) //
+						.onAfterProcessImage(() -> {
+							int expectedFirstValue = this.getSolarPredictionValue(currentHour);
+							executor.update();
+							Prediction prediction = sut.createNewPrediction(sut.getChannelAddresses()[0]);
+							assertNotEquals(Prediction.EMPTY_PREDICTION, prediction);
+							assertEquals(expectedFirstValue, prediction.getFirst().intValue());
+						}))
+				.deactivate();
 
+		// API response manual
+		new ComponentTest(sut)
 				// Case: response handling (manual)
-				.next(new TestCase("API response").onBeforeProcessImage(() -> {
-					// simulate response
-					String jsonResponse = this.generateDynamicJson(60);
-					api.handleResponse(HttpResponse.ok(jsonResponse));
-					assertNotEquals(TimeOfUsePrices.EMPTY_PRICES, api.getPrediction());
-				}))//
-				
+				.next(new TestCase("API response") //
+						.onBeforeProcessImage(() -> {
+							// simulate response
+							String jsonResponse = this.generateDynamicJson(clock, 60);
+							api.handleResponse(HttpResponse.ok(jsonResponse));
+							assertNotEquals(Prediction.EMPTY_PREDICTION, api.getPrediction());
+						}))//
+
 				// Case: simulated API processing (60 minutes)
-				.next(new TestCase("Successful API response").onBeforeProcessImage(() -> {
-					String jsonResponse = this.generateDynamicJson(60);
-					assertEquals(Prediction.EMPTY_PREDICTION, sut.createNewPrediction(sut.getChannelAddresses()[0]));
+				.next(new TestCase("Successful API response") //
+						.timeleap(clock, 6, ChronoUnit.HOURS) //
+						.onBeforeProcessImage(() -> {
+							assertEquals(Prediction.EMPTY_PREDICTION, api.getPrediction());
+							assertEquals(null, api.getCurrentPrediction());
 
-					Prediction prediction = api.parsePrediction(jsonResponse);
-					assertNotEquals(Prediction.EMPTY_PREDICTION, prediction);
+							String jsonResponse = this.generateDynamicJson(clock, 60);
+							Prediction prediction = api.parsePrediction(jsonResponse);
+							assertNotEquals(Prediction.EMPTY_PREDICTION, prediction);
 
-					Integer[] predictions = prediction.asArray();
+							Integer[] predictions = prediction.asArray();
 
-					// check object count
-					assertEquals(8, predictions.length);
+							// check object count
+							assertEquals(8, predictions.length);
 
-					// check first timestamp (in UTC)
-					assertEquals(currentHour, prediction.getFirstTime());
+							// check first timestamp (in UTC, respecting time leap)
+							assertEquals(currentHour.plusHours(6), prediction.getFirstTime());
 
-					// check quaterly values
-					assertEquals(expectedFirstValue, predictions[0].intValue());
-					assertEquals(expectedFirstValue, predictions[1].intValue());
-					assertEquals(expectedFirstValue, predictions[2].intValue());
-					assertEquals(expectedFirstValue, predictions[3].intValue());
+							int expectedFirstValue = this.getSolarPredictionValue(currentHour.plusHours(6));
+							// check quaterly values
+							assertEquals(expectedFirstValue, predictions[0].intValue());
+							assertEquals(expectedFirstValue, predictions[1].intValue());
+							assertEquals(expectedFirstValue, predictions[2].intValue());
+							assertEquals(expectedFirstValue, predictions[3].intValue());
 
-					// check first value of next hour
-					assertEquals(expectedSecondHourValue, predictions[4].intValue());
-				})) //
+							// check first value of next hour
+							int expectedSecondHourValue = this.getSolarPredictionValue(currentHour.plusHours(7));
+							assertEquals(expectedSecondHourValue, predictions[4].intValue());
+						})) //
 
 				// Case: simulated API processing (30 minutes)
-				.next(new TestCase("Successful API response").onBeforeProcessImage(() -> {
-					String jsonResponse = this.generateDynamicJson(30);
-					Prediction prediction = api.parsePrediction(jsonResponse);
-					assertNotEquals(Prediction.EMPTY_PREDICTION, prediction);
+				.next(new TestCase("Successful API response") //
+						.onBeforeProcessImage(() -> {
+							String jsonResponse = this.generateDynamicJson(clock, 30);
+							Prediction prediction = api.parsePrediction(jsonResponse);
+							assertNotEquals(Prediction.EMPTY_PREDICTION, prediction);
 
-					Integer[] predictions = prediction.asArray();
+							Integer[] predictions = prediction.asArray();
 
-					// check object count
-					assertEquals(8, predictions.length);
+							// check object count
+							assertEquals(8, predictions.length);
 
-					// check first timestamp (in UTC)
-					assertEquals(currentHour, prediction.getFirstTime());
+							// check first timestamp (in UTC)
+							assertEquals(currentHour.plusHours(6), prediction.getFirstTime());
 
-					// check quaterly values
-					assertEquals(expectedFirstValue, predictions[0].intValue());
-					assertEquals(expectedFirstValue, predictions[1].intValue());
-					assertEquals(expectedFirstValue, predictions[2].intValue());
-					assertEquals(expectedFirstValue, predictions[3].intValue());
+							int expectedFirstValue = this.getSolarPredictionValue(currentHour.plusHours(6));
+							// check quaterly values
+							assertEquals(expectedFirstValue, predictions[0].intValue());
+							assertEquals(expectedFirstValue, predictions[1].intValue());
+							assertEquals(expectedFirstValue, predictions[2].intValue());
+							assertEquals(expectedFirstValue, predictions[3].intValue());
 
-					// check first value of next hour
-					assertEquals(expectedSecondHourValue, predictions[4].intValue());
-				})) //
+							// check first value of next hour
+							int expectedSecondHourValue = this.getSolarPredictionValue(currentHour.plusHours(7));
+							assertEquals(expectedSecondHourValue, predictions[4].intValue());
+						})) //
 
 				// Case: simulated API processing (15 minutes)
-				.next(new TestCase("Successful API response").onBeforeProcessImage(() -> {
-					String jsonResponse = this.generateDynamicJson(15);
-					Prediction prediction = api.parsePrediction(jsonResponse);
-					assertNotEquals(Prediction.EMPTY_PREDICTION, prediction);
+				.next(new TestCase("Successful API response") //
+						.onBeforeProcessImage(() -> {
+							String jsonResponse = this.generateDynamicJson(clock, 15);
+							Prediction prediction = api.parsePrediction(jsonResponse);
+							assertNotEquals(Prediction.EMPTY_PREDICTION, prediction);
 
-					Integer[] predictions = prediction.asArray();
+							Integer[] predictions = prediction.asArray();
 
-					// check object count
-					assertEquals(8, predictions.length);
+							// check object count
+							assertEquals(8, predictions.length);
 
-					// check first timestamp (in UTC)
-					assertEquals(currentHour, prediction.getFirstTime());
+							// check first timestamp (in UTC)
+							assertEquals(currentHour.plusHours(6), prediction.getFirstTime());
 
-					// check quaterly values
-					assertEquals(expectedFirstValue, predictions[0].intValue());
-					assertEquals(expectedFirstValue, predictions[1].intValue());
-					assertEquals(expectedFirstValue, predictions[2].intValue());
-					assertEquals(expectedFirstValue, predictions[3].intValue());
+							int expectedFirstValue = this.getSolarPredictionValue(currentHour.plusHours(6));
+							// check quaterly values
+							assertEquals(expectedFirstValue, predictions[0].intValue());
+							assertEquals(expectedFirstValue, predictions[1].intValue());
+							assertEquals(expectedFirstValue, predictions[2].intValue());
+							assertEquals(expectedFirstValue, predictions[3].intValue());
 
-					// check first value of next hour
-					assertEquals(expectedSecondHourValue, predictions[4].intValue());
-				})) //
-				
+							// check first value of next hour
+							int expectedSecondHourValue = this.getSolarPredictionValue(currentHour.plusHours(7));
+							assertEquals(expectedSecondHourValue, predictions[4].intValue());
+						})) //
+
+				// Case: simulated API processing (old data, caching)
+				.next(new TestCase("Successful API response") //
+						.timeleap(clock, -6, ChronoUnit.HOURS) //
+						.onBeforeProcessImage(() -> {
+
+							String jsonResponsePast = String.format(
+									"""
+											    { "result": { "rates": [{ "start": "%s", "end": "%s", "value": 100 },{ "start": "%s", "end": "%s", "value": 200 }]}}
+											""",
+									currentHour.minusMinutes(120), currentHour.minusMinutes(60),
+									currentHour.minusMinutes(60), currentHour);
+
+							Prediction prediction = api.parsePrediction(jsonResponsePast);
+							assertEquals(Prediction.EMPTY_PREDICTION, prediction);
+
+							Integer[] predictions = prediction.asArray();
+
+							// no future data
+							assertEquals(0, predictions.length);
+
+							String jsonResponseOld = String.format(
+									"""
+											    { "result": { "rates": [{ "start": "%s", "end": "%s", "value": 100 },{ "start": "%s", "end": "%s", "value": 200 }]}}
+											""",
+									currentHour.minusMinutes(60), currentHour, currentHour,
+									currentHour.plusMinutes(60));
+
+							prediction = api.parsePrediction(jsonResponseOld);
+							assertNotEquals(Prediction.EMPTY_PREDICTION, prediction);
+
+							predictions = prediction.asArray();
+
+							// past data is dropped
+							assertEquals(4, predictions.length);
+
+							// check first timestamp (in UTC) from second dataset
+							assertEquals(currentHour, prediction.getFirstTime());
+
+							// check quaterly values
+							assertEquals(200, predictions[0].intValue());
+							assertEquals(200, predictions[1].intValue());
+							assertEquals(200, predictions[2].intValue());
+							assertEquals(200, predictions[3].intValue());
+
+							// should cache stored values on old retrieval
+							api.handleResponse(HttpResponse.ok(jsonResponsePast));
+							assertNotEquals(Prediction.EMPTY_PREDICTION, api.getPrediction());
+
+							predictions = prediction.asArray();
+
+							// past data is dropped
+							assertEquals(4, predictions.length);
+
+							// check first timestamp (in UTC) from second dataset
+							assertEquals(currentHour, prediction.getFirstTime());
+
+							// check quaterly values
+							assertEquals(200, predictions[0].intValue());
+							assertEquals(200, predictions[1].intValue());
+							assertEquals(200, predictions[2].intValue());
+							assertEquals(200, predictions[3].intValue());
+
+						})) //
+
+				// Case: simulated API processing (invalid data, caching)
+				.next(new TestCase("Successful API response") //
+						.onBeforeProcessImage(() -> {
+							// JSON data
+							final String jsonResponseInvalid = String.format(
+									"""
+											    { "res": { "rates": [{ "start": "%s", "end": "%s", "value": 100 },{ "start": "%s", "end": "%s", "value": 200 }]}}
+											""",
+									currentHour, currentHour.plusHours(1), currentHour.plusHours(1),
+									currentHour.plusHours(2));
+
+							final String jsonResponseInvalidData = String.format(
+									"""
+											    { "result": { "rates": [{ "start": "%s", "end": "%s", "val": 100 },{ "start": "%s", "end": "%s", "val": 200 }]}}
+											""",
+									currentHour, currentHour.plusHours(1), currentHour.plusHours(1),
+									currentHour.plusHours(2));
+
+							// should have been initialized before
+							assertNotEquals(Prediction.EMPTY_PREDICTION, api.getPrediction());
+
+							Prediction prediction = api.parsePrediction(jsonResponseInvalid);
+							assertEquals(Prediction.EMPTY_PREDICTION, prediction);
+							assertNotEquals(Prediction.EMPTY_PREDICTION, api.getPrediction());
+
+							prediction = api.parsePrediction(jsonResponseInvalidData);
+							assertEquals(Prediction.EMPTY_PREDICTION, prediction);
+							assertNotEquals(Prediction.EMPTY_PREDICTION, api.getPrediction());
+
+						})) //
+
 				.deactivate();
 	}
 
-	private String generateDynamicJson(int minutes) {
-		ZonedDateTime now = ZonedDateTime.now().withMinute(0).withSecond(0).withNano(0);
+	private String generateDynamicJson(Clock clock, int minutes) {
+		ZonedDateTime now = ZonedDateTime.now(clock).withMinute(0).withSecond(0).withNano(0);
 		ZonedDateTime endTime = now.plusHours(2);
 
 		StringBuilder jsonBuilder = new StringBuilder();


### PR DESCRIPTION
## Summary by Sourcery

Refactor solar and grid tariff predictor implementations and tests to inject a controllable Clock, use a dummy HTTP bridge factory for deterministic HTTP interactions, enhance JSON parsing and caching logic, and cover various error and edge cases.

Bug Fixes:
- Ensure asynchronous HTTP calls in tests complete by adding timeleap and executor.update before assertions
- Fix empty prediction resets by retaining previous valid data when API responses are missing or invalid

Enhancements:
- Refactor unit tests to use DummyBridgeHttpFactory with cycleSubscriber, endpointFetcher, and dummyBridgeHttpExecutor instead of DummyBridgeHttpBundle
- Inject Clock into PredictorSolarTariffEvccApi and TimeOfUseGridTariffEvccApi and use it for all time calculations
- Enhance solar tariff JSON parsing to convert timestamps to UTC, handle 15/30/60-minute intervals, and log unexpected durations
- Update API clients to preserve last valid prediction/prices on parse errors and improve error logging

Tests:
- Add comprehensive test cases for API not found, unknown errors, manual responses, rate interval variations, caching of old data, and invalid data handling for both solar and grid tariff predictors